### PR TITLE
corregido string en JSON

### DIFF
--- a/api/src/data/bookings.json
+++ b/api/src/data/bookings.json
@@ -61,7 +61,7 @@
         "bikeIds":[1],
         "AccIds":[1],
         "totalPrice":1000,
-        "status": "cancell"
+        "status": "cancelled"
     }
 
 ]


### PR DESCRIPTION
En el JSON de Booking habia un status que decia "cancell" en lugar de "cancelled"